### PR TITLE
fix: zoom on click selector

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ const config = {
   projectName: "signoz", // Usually your repo name.
   themeConfig: {
     zoom: {
-      selector: '.markdown :not(em) > img',
+      selector: 'figure[data-zoomable] > img',
       config: {
         // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
         background: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,6 +27,10 @@ figure {
   margin: 0;
 }
 
+nav {
+  z-index: auto !important;
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgb(72, 77, 91);
   display: block;


### PR DESCRIPTION
New format of adding zoom on click
```html
<figure data-zoomable>
    <img src="/img/blog/2022/03/opentelemetry_vs_jaeger.webp"/>
</figure>
```