### PR TITLE
link update

### DIFF
--- a/blog/2022-04-13-opentelemetry-grpc-golang.md
+++ b/blog/2022-04-13-opentelemetry-grpc-golang.md
@@ -119,8 +119,8 @@ Our application is a simple Employee Service. Here is the architecture of the ap
         export PATH="$PATH:$(go env GOPATH)/bin"
         ```
         
-- MongoDB<br></br>
-Follow the steps in this <a href = "https://www.geeksforgeeks.org/how-to-install-mongodb-on-macos/" rel="noopener noreferrer nofollow" target="_blank">link</a> for how to install MongoDB.
+- MongoDB Compass <br></br>
+Download from Official site here <a href = "https://www.mongodb.com/try/download/compass" rel="noopener noreferrer nofollow" target="_blank">link</a>.
 
 ### Running a sample application with OpenTelemetry
 


### PR DESCRIPTION
Blog uses MongoDB compass (GUI based), but the link for installation steps in blog point to GeeksForGeeks for installing MongoDB community edition (terminal based).