### PR TITLE
Remove `OTEL_METRICS_EXPORTER=none` from Java and Python docs

### DIFF
--- a/blog/2021-06-02-python-application-monitoring.md
+++ b/blog/2021-06-02-python-application-monitoring.md
@@ -218,7 +218,7 @@ On MacOS the installation is done using Homebrew's brew package manager. Once th
    :::
    
    ```jsx
-   OTEL_RESOURCE_ATTRIBUTES=service.name=<service_name> OTEL_METRICS_EXPORTER=none OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz>:4317" opentelemetry-instrument python3 app.py
+   OTEL_RESOURCE_ATTRIBUTES=service.name=<service_name> OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz>:4317" opentelemetry-instrument python3 app.py
    ```
 
    As we are running SigNoz on local host, `IP of SigNoz` can be replaced with `localhost` in this case. And, for `service_name` let's use `pythonApp`. Hence, the final command becomes:
@@ -226,7 +226,7 @@ On MacOS the installation is done using Homebrew's brew package manager. Once th
    **Final Command**
 
    ```
-   OTEL_RESOURCE_ATTRIBUTES=service.name=pythonApp OTEL_METRICS_EXPORTER=none OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" opentelemetry-instrument python3 app.py
+   OTEL_RESOURCE_ATTRIBUTES=service.name=pythonApp OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" opentelemetry-instrument python3 app.py
    ```
 
 And, congratulations! You have instrumented your sample Python app. You can now access the SigNoz dashboard at [http://localhost:3301](http://localhost:3301/) to monitor your app for performance metrics.

--- a/blog/2021-11-19-opentelemetry-flask.md
+++ b/blog/2021-11-19-opentelemetry-flask.md
@@ -152,7 +152,7 @@ To capture data with OpenTelemetry, you need to configure some environment varia
    As we are running SigNoz on local host, `IP of SigNoz` can be replaced with `localhost` in this case. And, for `service_name` let's use `Flask_App`. Hence, the final command becomes:<br></br>
    **Final Command**
    ```jsx
-   OTEL_RESOURCE_ATTRIBUTES=service.name=Flask_App OTEL_METRICS_EXPORTER=none OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" opentelemetry-instrument python3 app.py
+   OTEL_RESOURCE_ATTRIBUTES=service.name=Flask_App OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" opentelemetry-instrument python3 app.py
    ```
 
    And congratulations! You have now instrumented your flask application with OpenTelemetry.

--- a/blog/2022-01-13-opentelemetry-django.md
+++ b/blog/2022-01-13-opentelemetry-django.md
@@ -186,7 +186,7 @@ There are two other ways to run the Django app with OpenTelemetry using Docker a
 
 b. **If want to run docker image of django app directly**<br></br>
 ```jsx
-docker run --env OTEL_METRICS_EXPORTER=none \
+docker run --env \
     --env OTEL_SERVICE_NAME=djangoApp \
     --env OTEL_EXPORTER_OTLP_ENDPOINT=http://<IP of SigNoz>:4317 \
     --env DJANGO_SETTINGS_MODULE=mysite.settings \
@@ -203,7 +203,6 @@ django-app:
     ports:
       - "8000:8000"
     environment:
-    - OTEL_METRICS_EXPORTER=none
     - OTEL_SERVICE_NAME=djangoApp
     - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
     - DJANGO_SETTINGS_MODULE=mysite.settings

--- a/docs/instrumentation/java.md
+++ b/docs/instrumentation/java.md
@@ -163,7 +163,7 @@ If you run your Java application as a JAR file, please follow the below instruct
 
 
 ```bash
-OTEL_METRICS_EXPORTER=none OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
+OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
 ```
 
 where <app_name> is the name you want to set for your application. `path` should be updated to the path of downloaded Java JAR agent.
@@ -197,7 +197,6 @@ This should set these environment variables and start sending telemetry data to 
 ```bash
 
 export CATALINA_OPTS="$CATALINA_OPTS -javaagent:/path/to/opentelemetry-javaagent.jar"
-export OTEL_METRICS_EXPORTER=none
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://<IP of SigNoz Backend>:4317
 export OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name>
 

--- a/docs/instrumentation/jboss.md
+++ b/docs/instrumentation/jboss.md
@@ -146,7 +146,7 @@ If you run your Java application as a JAR file, please follow the below instruct
 
 
 ```bash
-OTEL_METRICS_EXPORTER=none OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
+OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
 ```
 
 where <app_name> is the name you want to set for your application. `path` should be updated to the path of downloaded Java JAR agent.

--- a/docs/instrumentation/springboot.md
+++ b/docs/instrumentation/springboot.md
@@ -158,7 +158,7 @@ If you run your Java application as a JAR file, please follow the below instruct
 
 
 ```bash
-OTEL_METRICS_EXPORTER=none OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
+OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
 ```
 
 where <app_name> is the name you want to set for your application. `path` should be updated to the path of downloaded Java JAR agent.

--- a/docs/instrumentation/tomcat.md
+++ b/docs/instrumentation/tomcat.md
@@ -162,7 +162,7 @@ If you run your Java application as a JAR file, please follow the below instruct
 
 
 ```bash
-OTEL_METRICS_EXPORTER=none OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
+OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
 ```
 
 where <app_name> is the name you want to set for your application. `path` should be updated to the path of downloaded Java JAR agent.

--- a/docs/userguide/collecting_application_logs_otel_sdk_java.md
+++ b/docs/userguide/collecting_application_logs_otel_sdk_java.md
@@ -16,7 +16,7 @@ To sends logs from a Java application you will have to add the agent and add the
 
 The command for it will look like
 ```bash
-OTEL_METRICS_EXPORTER=none OTEL_LOGS_EXPORTER=otlp OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
+OTEL_LOGS_EXPORTER=otlp OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz Backend>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=<app_name> java -javaagent:/path/opentelemetry-javaagent.jar -jar  <myapp>.jar
 ```
 <br></br>
 
@@ -28,7 +28,7 @@ In the below example we will configure a java application to send logs to SigNoz
 * Build the application using `./mvnw package`
 * Now run the application
   ```
-  OTEL_METRICS_EXPORTER=none OTEL_LOGS_EXPORTER=otlp OTEL_EXPORTER_OTLP_ENDPOINT="http://<host>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=myapp java -javaagent:/path/opentelemetry-javaagent.jar -jar target/*.jar
+  OTEL_LOGS_EXPORTER=otlp OTEL_EXPORTER_OTLP_ENDPOINT="http://<host>:4317" OTEL_RESOURCE_ATTRIBUTES=service.name=myapp java -javaagent:/path/opentelemetry-javaagent.jar -jar target/*.jar
   ```
   
   You will have to replace your the value of `host` as  `0.0.0.0` if SigNoz is running in the same host, for other configurations please check the 

--- a/opentelemetry/2021-08-17-opentelemetry-java-auto-instrumentation.md
+++ b/opentelemetry/2021-08-17-opentelemetry-java-auto-instrumentation.md
@@ -57,7 +57,6 @@ Examples of some of the environment variables to take care of:
 
 ```
 OTEL_TRACES_EXPORTER=otlp
-OTEL_METRICS_EXPORTER=none
 OTEL_EXPORTER_OTLP_ENDPOINT=<IP of SigNoz Backend>:4317
 OTEL_RESOURCE_ATTRIBUTES="service.name=SERVICE_NAME"
 ```
@@ -71,7 +70,6 @@ java -javaagent:/path/to/opentelemetry-javaagent-all.jar -jar target/*.jar
 The path needs to be replaced with the address of the location where you have downloaded the saved the Java agent file. So the final command from terminal will look like this:
 
 ```
-OTEL_METRICS_EXPORTER=none
 OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz>:4317"
 OTEL_RESOURCE_ATTRIBUTES=service.name=javaApp
 java -javaagent:/Users/Downloads/to/opentelemetry-javaagent-all.jar -jar target/*.jar

--- a/opentelemetry/2021-08-17-opentelemetry-python.md
+++ b/opentelemetry/2021-08-17-opentelemetry-python.md
@@ -180,7 +180,7 @@ The application list shown in the dashboard is from a sample app called HOT R.O.
    :::
    
    ```jsx
-   OTEL_RESOURCE_ATTRIBUTES=service.name=<service_name> OTEL_METRICS_EXPORTER=none OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz>:4317" opentelemetry-instrument python3 app.py
+   OTEL_RESOURCE_ATTRIBUTES=service.name=<service_name> OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz>:4317" opentelemetry-instrument python3 app.py
    ```
 
    As we are running SigNoz on local host, `IP of SigNoz` can be replaced with `localhost` in this case. And, for `service_name` let's use `pythonApp`. Hence, the final command becomes:
@@ -188,7 +188,7 @@ The application list shown in the dashboard is from a sample app called HOT R.O.
    **Final Command**
 
    ```
-   OTEL_RESOURCE_ATTRIBUTES=service.name=pythonApp OTEL_METRICS_EXPORTER=none OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" opentelemetry-instrument python3 app.py
+   OTEL_RESOURCE_ATTRIBUTES=service.name=pythonApp OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" opentelemetry-instrument python3 app.py
    ```
 
    And, congratulations! You have instrumented your sample Python app. You can now access the SigNoz dashboard at [http://localhost:3301](http://localhost:3301/) to monitor your app for performance metrics.

--- a/opentelemetry/2022-03-10-everything-you-need-to-know-about-opentelemetry-java-agent.md
+++ b/opentelemetry/2022-03-10-everything-you-need-to-know-about-opentelemetry-java-agent.md
@@ -74,7 +74,6 @@ Examples of some of the environment variables to take care of:
 
 ```
 OTEL_TRACES_EXPORTER=otlp
-OTEL_METRICS_EXPORTER=none
 OTEL_EXPORTER_OTLP_ENDPOINT=<IP of SigNoz Backend>:4317
 OTEL_RESOURCE_ATTRIBUTES="service.name=SERVICE_NAME"
 ```
@@ -82,7 +81,6 @@ OTEL_RESOURCE_ATTRIBUTES="service.name=SERVICE_NAME"
 Let's see how the command looks like when you want to run the Java agent attached to an application:
 
 ```
-OTEL_METRICS_EXPORTER=none
 OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz>:4317"
 OTEL_RESOURCE_ATTRIBUTES=service.name=javaApp
 java -javaagent:/path/to/opentelemetry-javaagent-all.jar -jar target/*.jar
@@ -91,7 +89,6 @@ java -javaagent:/path/to/opentelemetry-javaagent-all.jar -jar target/*.jar
 The path to the Java agent JAR file needs to be replaced with the location of the file downloaded. For example, for my local, the command looks like this:
 
 ```
-OTEL_METRICS_EXPORTER=none
 OTEL_EXPORTER_OTLP_ENDPOINT="http://<IP of SigNoz>:4317"
 OTEL_RESOURCE_ATTRIBUTES=service.name=javaApp
 java -javaagent:/Users/Downloads/to/opentelemetry-javaagent-all.jar -jar target/*.jar


### PR DESCRIPTION
Part of https://github.com/SigNoz/signoz.io/issues/591

This is no longer needed for Python & Java (both have GA for tracing/metrics) docs. If applications are sending metrics we should allow them. Note: You will find it still being used in go because its metrics SDK is not ready yet.