### PR TITLE
update blog

### DIFF
--- a/blog/2022-04-13-opentelemetry-grpc-golang.md
+++ b/blog/2022-04-13-opentelemetry-grpc-golang.md
@@ -238,6 +238,14 @@ OTEL_SERVICE_NAME="go-grpc-otel-client"
 INSECURE_MODE=true
 ```
 
+:::info
+
+Do not use `http` or `https` in the IP address. For example, if the IP is `http://test.com` then the `OTEL_EXPORTER_OTLP_ENDPOINT` will be `test.com:4317`
+
+:::
+
+
+
 You can check the client env [file](https://github.com/SigNoz/distributed-tracing-go-grpc-sample/blob/main/client/.env) and server env [file](https://github.com/SigNoz/distributed-tracing-go-grpc-sample/blob/main/server/.env) in the sample GitHub repo.
 
 <!-- ![.env files loading in both *server/server.go* and *client/client.go.*](Ashu%20-%20Mon%2092dcf/Untitled%203.png) -->
@@ -258,7 +266,7 @@ You can check the client env [file](https://github.com/SigNoz/distributed-traci
   <img src="/img/blog/2022/04/grpc_mongodb_connection.webp" alt="MongoDB Data Connection" width="90%" />
 </figure>  
 
-2. Click on Databases tab → Create Database and fill in the fields like the below screenshot
+1. Click on Databases tab → Create Database and fill in the fields like the below screenshot
    <figure align="center">
   <img src="/img/blog/2022/04/grpc_create_database.webp" alt="Create Database" width="80%" />
 </figure>

--- a/blog/2022-04-13-opentelemetry-grpc-golang.md
+++ b/blog/2022-04-13-opentelemetry-grpc-golang.md
@@ -1,7 +1,7 @@
 ---
 title: Monitor gRPC calls with OpenTelemetry - explained with a Golang example
 slug: opentelemetry-grpc-golang
-date: 2022-10-28
+date: 2023-02-04
 tags: [OpenTelemetry Instrumentation, Go / Golang]
 authors: vaishnavi
 description: This article demonstrates how to monitor gRPC calls with OpenTelemetry using a sample Golang application using gRPC framework. OpenTelemetry is a vendor-agnostic instrumentation library that can be used to monitor gRPC calls...

--- a/blog/2022-04-30-opentelemetry-gin.md
+++ b/blog/2022-04-30-opentelemetry-gin.md
@@ -1,7 +1,7 @@
 ---
 title: Implementing OpenTelemetry in a Gin application 
 slug: opentelemetry-gin
-date: 2022-05-30
+date: 2023-02-03
 tags: [OpenTelemetry Instrumentation, Go / Golang]
 authors: [nitya, ankit_anand]
 description:  It is essential to monitor your Gin apps in Go(Golang). OpenTelemetry can help instrument Gin apps and provide you with end-to-end tracing. In this guide, we will demonstrate how to instrument your Gin app with OpenTelemetry...

--- a/blog/2022-04-30-opentelemetry-gin.md
+++ b/blog/2022-04-30-opentelemetry-gin.md
@@ -213,6 +213,14 @@ Hence, the final run command looks like this:
 SERVICE_NAME=goGinApp INSECURE_MODE=true OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 go run main.go
 ```
 
+
+:::info
+
+Do not use `http` or `https` in the IP address. For example, if the IP is `http://test.com` then the `OTEL_EXPORTER_OTLP_ENDPOINT` will be `test.com:4317`
+
+:::
+
+
 **Step 8:** **Generate some data**<br></br>
 In order to monitor your Gin application with SigNoz, you first need to generate some data.
 

--- a/blog/2022-05-21-monitoring-your-go-application-with-signoz.md
+++ b/blog/2022-05-21-monitoring-your-go-application-with-signoz.md
@@ -312,6 +312,14 @@ Hence, the final run command looks like this:
 SERVICE_NAME=goGinApp INSECURE_MODE=true OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 go run main.go
 ```
 
+
+:::info
+
+Do not use `http` or `https` in the IP address. For example, if the IP is `http://test.com` then the `OTEL_EXPORTER_OTLP_ENDPOINT` will be `test.com:4317`
+
+:::
+
+
 And, congratulations! You have instrumented your sample Golang app.
 
 Hit the `/books` endpoint of the bookstore app at [http://localhost:8090/books](http://localhost:8090/books). Refresh it a bunch of times in order to generate load, and wait for 1-2 mins for data to appear on SigNoz dashboard.

--- a/blog/2022-05-21-monitoring-your-go-application-with-signoz.md
+++ b/blog/2022-05-21-monitoring-your-go-application-with-signoz.md
@@ -1,7 +1,7 @@
 ---
 title: How to set up Golang application performance monitoring with open source monitoring tool - SigNoz
 slug: monitoring-your-go-application-with-signoz
-date: 2022-05-30
+date: 2023-02-02
 tags: [OpenTelemetry Instrumentation, Go / Golang]
 authors: ankit_anand
 description: In this article, learn how to setup application monitoring for Golang apps using an open-source solution, SigNoz.

--- a/blog/2022-05-28-distributed-tracing-golang.md
+++ b/blog/2022-05-28-distributed-tracing-golang.md
@@ -1,7 +1,7 @@
 ---
 title: Implementing Distributed Tracing in a Golang application
 slug: distributed-tracing-golang
-date: 2022-05-28
+date: 2023-02-01
 tags: [OpenTelemetry Instrumentation, Go / Golang]
 authors: [naman]
 description: Distributed tracing provides insights into how a particular service is performing as part of the whole in a distributed system. In this article, we will implement distributed tracing for a Golang application based on microservices architecture with OpenTelemetry, and visualize the collected data with SigNoz...

--- a/blog/2022-05-28-distributed-tracing-golang.md
+++ b/blog/2022-05-28-distributed-tracing-golang.md
@@ -262,7 +262,15 @@ OTLP endpoint for SigNoz - `<IP of the machine>:4317`
 
 If you have installed SigNoz on your local machine, then your endpoint is `127.0.0.1:4317`.
 
-If you have installed SigNoz on some domain, then your endpoint is `http://test.com:4317`
+If you have installed SigNoz on some domain, then your endpoint is `test.com:4317`
+
+
+:::info
+
+Do not use `http` or `https` in the IP address. 
+
+:::
+
 
 Configuration for the following can be set up in `.env`
 
@@ -282,6 +290,8 @@ SQL_DB=signoz
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
 INSECURE_MODE=true
 ```
+
+
 
 **Step 2: Run the microservices**
 


### PR DESCRIPTION
added the line to these blogs.

Do not use `http` or `https` in the IP address. For example, if the IP is `http://test.com` then the `OTEL_EXPORTER_OTLP_ENDPOINT` will be `test.com:4317`