### PR TITLE
Update instrumentation-using-opentelemetry-operator.md

### DIFF
--- a/docs/tutorial/instrumentation-using-opentelemetry-operator.md
+++ b/docs/tutorial/instrumentation-using-opentelemetry-operator.md
@@ -87,7 +87,7 @@ the sample collector:
 
 - To install `telemetrygen` binary:
   ```bash
-  go install github.com/open-telemetry/opentelemetry-collector-contrib/telemetrygen@latest
+  go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@latest
   ```
 - To forward gRPC port of the OTLP service:
   ```bash


### PR DESCRIPTION
Documentation is incorrect for this command, updated location can be found via https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen#section-readme