### PR TITLE
Update font of copyright text

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -249,6 +249,7 @@ hero__screenshot {
 
 .footer__copyright {
   text-align: center;
+  font-size: 14px;
 }
 
 .footer__links {


### PR DESCRIPTION
The font size of footer items and copyright text used to be the same. Reduced the font size to make it look better