### PR TITLE
Install newest OpenTelemetry packages as part of React tutorial

### DIFF
--- a/blog/2022-05-17-opentelemetry-react.md
+++ b/blog/2022-05-17-opentelemetry-react.md
@@ -155,7 +155,7 @@ _*Note: The stopped SigNoz cluster should resume and mount to the existing docke
 To instrument the React app with OpenTelemetry, we need to install the OpenTelemetry dependencies.
 
 ```bash
-yarn add -D @opentelemetry/api@1.0.3 @opentelemetry/context-zone@1.0.0 @opentelemetry/exporter-collector@0.25.0@opentelemetry/instrumentation-fetch@0.25.0
+yarn add -D @opentelemetry/api @opentelemetry/context-zone @opentelemetry/exporter-trace-otlp-http @opentelemetry/instrumentation-fetch
 ```
 
 **Step 5: Update Service Name and CollectorTrace Exporter**


### PR DESCRIPTION
Old versions do not work with current SigNoz and the issue is difficult to debug for beginners