### PR TITLE
fix:treosh/lighthouse-ci-action@v10

### DIFF
--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -4,10 +4,10 @@ on:
   pull_request_target:
     branches:
       - main
-      
+
 permissions:
   pull-requests: write
-  
+
 jobs:
   lighthouse-report:
     name: Lighthouse Report
@@ -22,7 +22,7 @@ jobs:
           max_timeout: 600
       - name: Audit URLs using Lighthouse
         id: lighthouse_audit
-        uses: treosh/lighthouse-ci-action@v10.1.0
+        uses: treosh/lighthouse-ci-action@v10
         with:
           urls: |
             https://deploy-preview-$PR_NUMBER--frosty-austin-928e43.netlify.app


### PR DESCRIPTION
change the version `treosh/lighthouse-ci-action@v10.1.0` -> `treosh/lighthouse-ci-action@v10`

![image](https://github.com/SigNoz/signoz.io/assets/52954931/7c90cad7-347f-4afb-b178-2c7ff6d73192)
