### PR TITLE
Incorrect docs: aws.md

### DIFF
--- a/docs/install/kubernetes/aws.md
+++ b/docs/install/kubernetes/aws.md
@@ -39,7 +39,7 @@ an overview of the parameters that can be configured during installation under
 ```yaml
 global:
   storageClass: gp2-resizable
-  cloud: gcp
+  cloud: aws
 
 clickhouse:
   installCustomStorageClass: true


### PR DESCRIPTION
Hey there,

I caught a slight issue with the docs for running signoz on aws. Looks like this part was copy/pasted from the google cloud section. See here: https://signoz.io/docs/install/kubernetes/aws/

Cheers,
- gaida