### PR TITLE
added new demo video

### DIFF
--- a/src/modules/index-header/index.tsx
+++ b/src/modules/index-header/index.tsx
@@ -104,7 +104,7 @@ needs - APM, logs, metrics, exceptions, alerts, and dashboards powered by a powe
       id={"demo-video-player"}
     >
       <source
-        src="https://demo-video-1.s3.us-east-2.amazonaws.com/SigNoz-Demo-Sept2-2022.mp4"
+        src="https://demo-video-1.s3.us-east-2.amazonaws.com/SigNozCompleteDemo-5Aug2023-HD1080p.mov"
         type="video/mp4"
       />
       Your browser does not support the video tag.


### PR DESCRIPTION
The video is added in s3.

Couple of issues:
- Too long video, so not suitable for quick viewing which is what users visiting front page may be looking for
- Since we are loading from s3, the initial load time is higher 4-5 sec - this way of showing may not be ideal for big video
- No chapters, as this is a raw file. For chapters we would need to embed something like a youtube link ( or may be vimeo)