### PR TITLE
docs(userguide): 📝 fixes typo on configuration section

### DIFF
--- a/docs/userguide/collecing_kubernetes_pod_logs.md
+++ b/docs/userguide/collecing_kubernetes_pod_logs.md
@@ -60,7 +60,7 @@ If your signoz cluster is hosted in a different cluster then you will have to in
   ```yaml
   k8s-infra:
     presets:
-      logCollection:
+      logsCollection:
         # whether to enable log collection
         enabled: true
         blacklist:


### PR DESCRIPTION
I just spend some time wondering why my changes to the k8s-infra component weren't being applied. Found the culprit in the documentation.