### PR TITLE
Update 2023-03-20-opentelemetry-browser-instrumentation.md

### DIFF
--- a/blog/2023-03-20-opentelemetry-browser-instrumentation.md
+++ b/blog/2023-03-20-opentelemetry-browser-instrumentation.md
@@ -91,7 +91,7 @@ Our application code consists of a `tracing.js` file. The `tracing.js` file cont
 To instrument the React app with OpenTelemetry, we need to install the OpenTelemetry dependencies.
 
 ```jsx
-npm i @opentelemetry/api @opentelemetry/auto-instrumentations-web, @opentelemetry/context-zone, @opentelemetry/exporter-trace-otlp-http @opentelemetry/instrumentation-fetch @opentelemetry/instrumentation-xml-http-request @opentelemetry/resources @opentelemetry/sdk-trace-web
+npm i @opentelemetry/api @opentelemetry/auto-instrumentations-web @opentelemetry/context-zone @opentelemetry/exporter-trace-otlp-http @opentelemetry/instrumentation-fetch @opentelemetry/instrumentation-xml-http-request @opentelemetry/resources @opentelemetry/sdk-trace-web
 ```
 
 Since we already set up the tracing.js file in the sample react app, you can just change the service name.


### PR DESCRIPTION
The original `npm install` command had two commas. This is invalid syntax as commas are not needed. When copied and pasted from your docs it would fail. This change removes the two commas and successfully installs all the packages from the command in the code block.