### PR TITLE
feat: updated Otel Binary Usage run command

### DIFF
--- a/docs/shared/otel-binary-execute-linux.md
+++ b/docs/shared/otel-binary-execute-linux.md
@@ -7,7 +7,7 @@ From the `otelcol-contrib`, run the following command:
 ```
 
 ### Run in background 
-If you want to run otel collector process in the background :
+If you want to run otel collector process in the background:
 
 ```bash
 ./otelcol-contrib --config ./config.yaml &> otelcol-output.log & echo "$!" > otel-pid

--- a/docs/shared/otel-binary-execute-linux.md
+++ b/docs/shared/otel-binary-execute-linux.md
@@ -1,5 +1,15 @@
-Run otel-collector agent with the configuration
+Once we are done with the above configurations, we can now run the collector service with the following command:
+
+From the `otelcol-contrib`, run the following command :
+
+```bash
+./otelcol-contrib --config ./config.yaml
+```
+
+### Run in background 
+If you want to run otel collector process in the background :
 
 ```bash
 ./otelcol-contrib --config ./config.yaml &> otelcol-output.log & echo "$!" > otel-pid
 ```
+The above command sends the output of the otel-collector to `otelcol-output.log` file and prints the process id of the background running otel collector process to the otel-pid file.

--- a/docs/shared/otel-binary-execute-linux.md
+++ b/docs/shared/otel-binary-execute-linux.md
@@ -1,6 +1,6 @@
 Once we are done with the above configurations, we can now run the collector service with the following command:
 
-From the `otelcol-contrib`, run the following command :
+From the `otelcol-contrib`, run the following command:
 
 ```bash
 ./otelcol-contrib --config ./config.yaml

--- a/docs/shared/otel-binary-execute-macos.md
+++ b/docs/shared/otel-binary-execute-macos.md
@@ -1,5 +1,16 @@
-Run otel-collector agent with the configuration
+Once we are done with the above configurations, we can now run the collector service with the following command:
+
+From the `otelcol-contrib`, run the following command :
+
+```bash
+./otelcol-contrib --config ./config.yaml
+```
+
+### Run in background 
+
+If you want to run otel collector process in the background :
 
 ```bash
 ./otelcol-contrib --config ./config.yaml &> otelcol-output.log & echo "$\!" > otel-pid
 ```
+The above command sends the output of the otel-collector to `otelcol-output.log` file and prints the process id of the background running otel collector process to the otel-pid file.

--- a/docs/shared/otel-binary-execute-macos.md
+++ b/docs/shared/otel-binary-execute-macos.md
@@ -8,7 +8,7 @@ From the `otelcol-contrib`, run the following command:
 
 ### Run in background 
 
-If you want to run otel collector process in the background :
+If you want to run otel collector process in the background:
 
 ```bash
 ./otelcol-contrib --config ./config.yaml &> otelcol-output.log & echo "$\!" > otel-pid

--- a/docs/shared/otel-binary-execute-macos.md
+++ b/docs/shared/otel-binary-execute-macos.md
@@ -1,6 +1,6 @@
 Once we are done with the above configurations, we can now run the collector service with the following command:
 
-From the `otelcol-contrib`, run the following command :
+From the `otelcol-contrib`, run the following command:
 
 ```bash
 ./otelcol-contrib --config ./config.yaml

--- a/docs/shared/otel-binary-logs.md
+++ b/docs/shared/otel-binary-logs.md
@@ -1,5 +1,5 @@
 
-If you want to see the output of the logs you’ve just set up for the background process, you may look it up with :
+If you want to see the output of the logs you’ve just set up for the background process, you may look it up with:
 
 ```bash
 tail -f -n 50 otelcol-output.log

--- a/docs/shared/otel-binary-logs.md
+++ b/docs/shared/otel-binary-logs.md
@@ -1,5 +1,7 @@
-To view last 50 lines of `otelcol` logs:
+
+If you want to see the output of the logs you’ve just set up for the background process, you may look it up with :
 
 ```bash
 tail -f -n 50 otelcol-output.log
 ```
+tail 50 will give the last 50 lines from the file `otelcol-output.log`

--- a/docs/shared/otel-binary-stop.md
+++ b/docs/shared/otel-binary-stop.md
@@ -1,5 +1,5 @@
 
-You can stop the collector service `otelcol` when running in backgorund, with the following command :
+You can stop the collector service `otelcol` when running in backgorund, with the following command:
 
 ```bash
 kill "$(< otel-pid)"

--- a/docs/shared/otel-binary-stop.md
+++ b/docs/shared/otel-binary-stop.md
@@ -1,4 +1,5 @@
-To stop `otelcol`:
+
+You can stop the collector service `otelcol` when running in backgorund, with the following command :
 
 ```bash
 kill "$(< otel-pid)"

--- a/docs/tutorial/opentelemetry-binary-usage.md
+++ b/docs/tutorial/opentelemetry-binary-usage.md
@@ -62,9 +62,9 @@ Here are the steps to set up OpenTelemetry binary as an agent.
 
 4. <OtelExecuteLinux />
 
-5. <TailLogs />
+   <TailLogs />
 
-6. <OtelStop />
+   <OtelStop />
 
 </TabItem>
 <TabItem value="linux-arm" label="Linux (arm64)">
@@ -77,9 +77,9 @@ Here are the steps to set up OpenTelemetry binary as an agent.
 
 4. <OtelExecuteLinux />
 
-5. <TailLogs />
+   <TailLogs />
 
-6. <OtelStop />
+   <OtelStop />
 
 </TabItem>
 <TabItem value="macos-amd" label="MacOS (amd64)">
@@ -92,9 +92,9 @@ Here are the steps to set up OpenTelemetry binary as an agent.
 
 4. <OtelExecuteMacos />
 
-5. <TailLogs />
+   <TailLogs />
 
-6. <OtelStop />
+   <OtelStop />
 
 </TabItem>
 <TabItem value="macos-arm" label="MacOS (arm64)">
@@ -107,9 +107,9 @@ Here are the steps to set up OpenTelemetry binary as an agent.
 
 4. <OtelExecuteMacos />
 
-5. <TailLogs />
+   <TailLogs />
 
-6. <OtelStop />
+  <OtelStop />
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Updated the run instructions on [here](https://signoz.io/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine/) taking a reference from [here](https://signoz.io/blog/opentelemetry-rabbitmq-metrics-monitoring/#step-4---running-the-collector-service)