### PR TITLE
Update external-clickhouse.md

### DIFF
--- a/docs/operate/clickhouse/external-clickhouse.md
+++ b/docs/operate/clickhouse/external-clickhouse.md
@@ -67,8 +67,8 @@ clickhouse:
 
 externalClickhouse:
   host: <clickhouse-endpoint>
-  httpPort: 8123
-  tcpPort: 9000
+  httpPort: "8123"
+  tcpPort: "9000"
   cluster: cluster
   secure: false
   user: <ch-user>


### PR DESCRIPTION
Updated Documentation for external-clickhouse where the tcpPort and httpPort should be of Type String instead of int/float in yaml.