### PR TITLE
Update s3-cold-storage-integration-with-aws-iam-role-eks.md

### DIFF
--- a/docs/tutorial/s3-cold-storage-integration-with-aws-iam-role-eks.md
+++ b/docs/tutorial/s3-cold-storage-integration-with-aws-iam-role-eks.md
@@ -131,7 +131,7 @@ clickhouse:
       role:
          enabled: true
          annotations:
-            eks.amazonaws.com/role-arn:arn:aws:iam::1234056789:role/demo-cold-storage-role
+            eks.amazonaws.com/role-arn: arn:aws:iam::1234056789:role/demo-cold-storage-role
 ```
 8. Upgrade the helm deployment.
 


### PR DESCRIPTION
Missing space after `eks.amazonaws.com/role-arn:`. Without the space, then helm yells at us for having an incorrect syntax since we are expected a key: string mapping and without the space it reads it as a string.