### PR TITLE
fix:added docs to sidebar which got removed resolving merge conflict

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -79,19 +79,29 @@ module.exports = {
       items: [
         {
           type: 'doc',
+          id: 'product-features/query-builder',
+          label: 'Query Builder',
+        },
+        {
+          type: 'doc',
           id: 'product-features/alert-management',
           label: 'Alert Management',
+        },
+        {
+          type: 'doc',
+          id: 'product-features/trace-explorer',
+          label: 'Trace Explorer',
+        },
+        {
+          type: 'doc',
+          id: 'product-features/logs-explorer',
+          label: 'Logs Explorer',
         },
         {
           type: 'doc',
           id: 'product-features/saved-view',
           label: 'Saved View',
           className: 'new-doc', // Add this line
-        },
-        {
-          type: 'doc',
-          id: 'product-features/logs-explorer',
-          label: 'Logs Explorer',
         },
       ]
     },


### PR DESCRIPTION
Added the QB and Trace Explorer docs to the sidebar under SigNoz Features. These got removed from `sidebar.js` when resolving merge conflicts.